### PR TITLE
Make use of global variable (flashcache_kcp_client)

### DIFF
--- a/src/flashcache_conf.c
+++ b/src/flashcache_conf.c
@@ -1808,8 +1808,8 @@ flashcache_init(void)
 	r = kcopyd_client_create(FLASHCACHE_COPY_PAGES, &flashcache_kcp_client);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)
 	flashcache_kcp_client = dm_kcopyd_client_create();
-	if ((r = IS_ERR(dmc->kcp_client))) {
-		r = PTR_ERR(dmc->kcp_client);
+	if ((r = IS_ERR(flashcache_kcp_client))) {
+		r = PTR_ERR(flashcache_kcp_client);
 	}
 #else /* .26 <= VERSION < 3.0.0 */
 	r = dm_kcopyd_client_create(FLASHCACHE_COPY_PAGES, &flashcache_kcp_client);


### PR DESCRIPTION
Make use of global variable (flashcache_kcp_client), which is newly added instead of the using the dm_kcopyd_client type present in the cache_c structure, which is removed.
