### PR TITLE
Making use of standard linked list manipulation macros for cache_head_list of type struct cache_c

### DIFF
--- a/src/flashcache.h
+++ b/src/flashcache.h
@@ -250,8 +250,7 @@ struct cache_c {
 #define PENDING_JOB_HASH_SIZE		32
 	struct pending_job *pending_job_hashbuckets[PENDING_JOB_HASH_SIZE];
 	
-	struct cache_c	*next_cache;
-
+	struct list_head cache_list;
 	void *sysctl_handle;
 
 	char cache_devname[DEV_PATHLEN];


### PR DESCRIPTION
Hi Mohan,

Would like you to review the patch.

Regards,
Rohan.
