### PR TITLE
Re: [flashcache-dev] sysctls with limits : saner code?

### DIFF
--- a/src/flashcache.h
+++ b/src/flashcache.h
@@ -271,7 +271,6 @@ struct cache_c {
 	int sysctl_fast_remove;
 	int sysctl_cache_all;
 	int sysctl_fallow_clean_speed;
-	int sysctl_fallow_clean_speed_new;
 	int sysctl_fallow_delay;
 };
 

--- a/src/flashcache_procfs.c
+++ b/src/flashcache_procfs.c
@@ -166,11 +166,11 @@ flashcache_fallow_clean_speed_sysctl(ctl_table *table, int write,
 	proc_dointvec(table, write, buffer, length, ppos);
 #endif
 	if (write) {
-		if (dmc->sysctl_fallow_clean_speed_new >= fallow_clean_speed_min &&
-		    dmc->sysctl_fallow_clean_speed_new <= fallow_clean_speed_max) {
-			dmc->sysctl_fallow_clean_speed = dmc->sysctl_fallow_clean_speed_new;
-		} else
-			dmc->sysctl_fallow_clean_speed_new = dmc->sysctl_fallow_clean_speed;
+		if (dmc->sysctl_fallow_clean_speed < fallow_clean_speed_min)
+			dmc->sysctl_fallow_clean_speed = fallow_clean_speed_min;
+
+		if (dmc->sysctl_fallow_clean_speed > fallow_clean_speed_max)
+			dmc->sysctl_fallow_clean_speed = fallow_clean_speed_max;
 	}
 	return 0;
 }
@@ -191,9 +191,12 @@ flashcache_dirty_thresh_sysctl(ctl_table *table, int write,
         proc_dointvec(table, write, buffer, length, ppos);
 #endif
 	if (write) {
-		if (dmc->sysctl_dirty_thresh > DIRTY_THRESH_MAX ||
-		    dmc->sysctl_dirty_thresh < DIRTY_THRESH_MIN)
-			dmc->sysctl_dirty_thresh = DIRTY_THRESH_DEF;
+		if (dmc->sysctl_dirty_thresh > DIRTY_THRESH_MAX)
+			dmc->sysctl_dirty_thresh = DIRTY_THRESH_MAX;
+
+		if (dmc->sysctl_dirty_thresh < DIRTY_THRESH_MIN)
+			dmc->sysctl_dirty_thresh = DIRTY_THRESH_MIN;
+
 		dmc->dirty_thresh_set = 
 			(dmc->assoc * dmc->sysctl_dirty_thresh) / 100;
 	}


### PR DESCRIPTION
Currently only the sysctls dirty_thresh_pct and fallow_clean_speed
have predefined limits.

However, the enforcement method is odd/broken :

1) fallow_clean_speed does not enforce the limits
2) dirty_thresh_pct gets set to the default if we request outside the
limits.

The attached patch keeps both parameters within their limits which
allowing max/min values to be used if the user tries to go outside
them, which is probably what the user wants.
