### PR TITLE
Removed lots of duplicated lines in #ifdef blocks in flashcache_conf.c and flashcache_procfs.c

### DIFF
--- a/src/flashcache_conf.c
+++ b/src/flashcache_conf.c
@@ -1214,143 +1214,71 @@ flashcache_dtr_stats_print(struct cache_c *dmc)
 	
 	DMINFO("stats: \n\treads(%lu), writes(%lu)", stats->reads, stats->writes);
 
-#ifdef FLASHCACHE_DO_CHECKSUMS
 	if (dmc->cache_mode == FLASHCACHE_WRITE_BACK) {
 		DMINFO("\tread hits(%lu), read hit percent(%d)\n"	\
 		       "\twrite hits(%lu) write hit percent(%d)\n"	\
 		       "\tdirty write hits(%lu) dirty write hit percent(%d)\n" \
 		       "\treplacement(%lu), write replacement(%lu)\n"	\
-		       "\twrite invalidates(%lu), read invalidates(%lu)\n" \
-		       "\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n" \
-		       "\tpending enqueues(%lu), pending inval(%lu)\n"	\
+		       "\twrite invalidates(%lu), read invalidates(%lu)\n" ,
+		       stats->read_hits, read_hit_pct,
+		       stats->write_hits, write_hit_pct,
+		       stats->dirty_write_hits, dirty_write_hit_pct,
+		       stats->replace, stats->wr_replace, 
+		       stats->wr_invalidates, stats->rd_invalidates);
+#ifdef FLASHCACHE_DO_CHECKSUMS
+		DMINFO("\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n",
+		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid);
+#endif
+		DMINFO("\tpending enqueues(%lu), pending inval(%lu)\n"	\
 		       "\tmetadata dirties(%lu), metadata cleans(%lu)\n" \
 		       "\tmetadata batch(%lu) metadata ssd writes(%lu)\n" \
 		       "\tcleanings(%lu) fallow cleanings(%lu)\n"	\
-		       "\tno room(%lu) front merge(%lu) back merge(%lu)\n" \
-		       "\tdisk reads(%lu), disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu), uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)",
-		       stats->read_hits, read_hit_pct,
-		       stats->write_hits, write_hit_pct,
-		       stats->dirty_write_hits, dirty_write_hit_pct,
-		       stats->replace, stats->wr_replace, 
-		       stats->wr_invalidates, stats->rd_invalidates,
-		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid,
+		       "\tno room(%lu) front merge(%lu) back merge(%lu)\n",
 		       stats->enqueues, stats->pending_inval,
 		       stats->md_write_dirty, stats->md_write_clean,
 		       stats->md_write_batch, stats->md_ssd_writes,
 		       stats->cleanings, stats->fallow_cleanings, 
-		       stats->noroom, stats->front_merge, stats->back_merge,
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
+		       stats->noroom, stats->front_merge, stats->back_merge);
 	} else if (dmc->cache_mode == FLASHCACHE_WRITE_THROUGH) {
 		DMINFO("\tread hits(%lu), read hit percent(%d)\n"	\
 		       "\twrite hits(%lu) write hit percent(%d)\n"	\
 		       "\treplacement(%lu)\n"				\
-		       "\twrite invalidates(%lu), read invalidates(%lu)\n" \
-		       "\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n" \
-		       "\tpending enqueues(%lu), pending inval(%lu)\n"	\
-		       "\tno room(%lu)\n"				\
-		       "\tdisk reads(%lu), disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu), uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)",
+		       "\twrite invalidates(%lu), read invalidates(%lu)\n",
 		       stats->read_hits, read_hit_pct,
 		       stats->write_hits, write_hit_pct,
 		       stats->replace,
-		       stats->wr_invalidates, stats->rd_invalidates,
-		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid,
+		       stats->wr_invalidates, stats->rd_invalidates);
+#ifdef FLASHCACHE_DO_CHECKSUMS
+		DMINFO("\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n",
+		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid);
+#endif
+		DMINFO("\tpending enqueues(%lu), pending inval(%lu)\n"	\
+		       "\tno room(%lu)\n",
 		       stats->enqueues, stats->pending_inval,
-		       stats->noroom, 
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
+		       stats->noroom);
 	} else 	{	/* WRITE_AROUND */
 		DMINFO("\tread hits(%lu), read hit percent(%d)\n"	\
 		       "\treplacement(%lu)\n"				\
-		       "\tinvalidates(%lu)\n"				\
-		       "\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n" \
-		       "\tpending enqueues(%lu), pending inval(%lu)\n"	\
-		       "\tno room(%lu)\n"				\
-		       "\tdisk reads(%lu), disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu), uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)",
+		       "\tinvalidates(%lu)\n",
 		       stats->read_hits, read_hit_pct,
 		       stats->replace,
-		       stats->rd_invalidates,
-		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid,
-		       stats->enqueues, stats->pending_inval,
-		       stats->noroom, 
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	}
-#else
-	if (dmc->cache_mode == FLASHCACHE_WRITE_BACK) {
-		DMINFO("\tread hits(%lu), read hit percent(%d)\n"	\
-		       "\twrite hits(%lu) write hit percent(%d)\n"	\
-		       "\tdirty write hits(%lu) dirty write hit percent(%d)\n" \
-		       "\treplacement(%lu) write replacement(%lu)\n"	\
-		       "\twrite invalidates(%lu) read invalidates(%lu)\n" \
-		       "\tpending enqueues(%lu) pending inval(%lu)\n"	\
-		       "\tmetadata dirties(%lu) metadata cleans(%lu)\n" \
-		       "\tmetadata batch(%lu) metadata ssd writes(%lu)\n" \
-		       "\tcleanings(%lu) fallow cleanings(%lu)\n"	\
-		       "\tno room(%lu) front merge(%lu) back merge(%lu)\n" \
-		       "\tdisk reads(%lu) disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu) uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu) pid_dels(%lu) pid_drops(%lu) pid_expiry(%lu)",
-		       stats->read_hits, read_hit_pct,
-		       stats->write_hits, write_hit_pct,
-		       stats->dirty_write_hits, dirty_write_hit_pct,
-		       stats->replace, stats->wr_replace, 
-		       stats->wr_invalidates, stats->rd_invalidates,
-		       stats->enqueues, stats->pending_inval,
-		       stats->md_write_dirty, stats->md_write_clean,
-		       stats->md_write_batch, stats->md_ssd_writes,
-		       stats->cleanings, stats->fallow_cleanings, 
-		       stats->noroom, stats->front_merge, stats->back_merge,
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	} else if (dmc->cache_mode == FLASHCACHE_WRITE_THROUGH) {
-		DMINFO("\tread hits(%lu), read hit percent(%d)\n"	\
-		       "\twrite hits(%lu) write hit percent(%d)\n"	\
-		       "\treplacement(%lu)\n"				\
-		       "\twrite invalidates(%lu) read invalidates(%lu)\n" \
-		       "\tpending enqueues(%lu) pending inval(%lu)\n"	\
-		       "\tno room(%lu)\n"				\
-		       "\tdisk reads(%lu) disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu) uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu) pid_dels(%lu) pid_drops(%lu) pid_expiry(%lu)",
-		       stats->read_hits, read_hit_pct,
-		       stats->write_hits, write_hit_pct,
-		       stats->replace,
-		       stats->wr_invalidates, stats->rd_invalidates,
-		       stats->enqueues, stats->pending_inval,
-		       stats->noroom, 
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	} else {	/* WRITE_AROUND */
-		DMINFO("\tread hits(%lu), read hit percent(%d)\n"	\
-		       "\treplacement(%lu))\n"				\
-		       "\tinvalidates(%lu)\n"				\
-		       "\tpending enqueues(%lu) pending inval(%lu)\n"	\
-		       "\tno room(%lu)\n"				\
-		       "\tdisk reads(%lu) disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu) uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu) pid_dels(%lu) pid_drops(%lu) pid_expiry(%lu)",
-		       stats->read_hits, read_hit_pct,
-		       stats->replace,
-		       stats->rd_invalidates,
-		       stats->enqueues, stats->pending_inval,
-		       stats->noroom, 
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	}
+		       stats->rd_invalidates);
+#ifdef FLASHCACHE_DO_CHECKSUMS
+		DMINFO("\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n",
+		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid);
 #endif
+		DMINFO("\tpending enqueues(%lu), pending inval(%lu)\n"	\
+		       "\tno room(%lu)\n",
+		       stats->enqueues, stats->pending_inval,
+		       stats->noroom);
+	}
+	/* All modes */
+        DMINFO("\tdisk reads(%lu), disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
+               "\tuncached reads(%lu), uncached writes(%lu), uncached IO requeue(%lu)\n" \
+               "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)",
+               stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
+               stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
+               stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
 	if (dmc->size > 0) {
 		dirty_pct = ((u_int64_t)dmc->nr_dirty * 100) / dmc->size;
 		cache_pct = ((u_int64_t)dmc->cached_blocks * 100) / dmc->size;
@@ -1462,143 +1390,71 @@ flashcache_status_info(struct cache_c *dmc, status_type_t type,
 	DMEMIT("stats: \n\treads(%lu), writes(%lu)\n", 
 	       stats->reads, stats->writes);
 
-#ifdef FLASHCACHE_DO_CHECKSUMS
 	if (dmc->cache_mode == FLASHCACHE_WRITE_BACK) {
 		DMEMIT("\tread hits(%lu), read hit percent(%d)\n"	\
 		       "\twrite hits(%lu) write hit percent(%d)\n"	\
 		       "\tdirty write hits(%lu) dirty write hit percent(%d)\n" \
 		       "\treplacement(%lu), write replacement(%lu)\n"	\
-		       "\twrite invalidates(%lu), read invalidates(%lu)\n" \
-		       "\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n" \
-		       "\tpending enqueues(%lu), pending inval(%lu)\n"	\
+		       "\twrite invalidates(%lu), read invalidates(%lu)\n",
+		       stats->read_hits, read_hit_pct,
+		       stats->write_hits, write_hit_pct,
+		       stats->dirty_write_hits, dirty_write_hit_pct,
+		       stats->replace, stats->wr_replace, 
+		       stats->wr_invalidates, stats->rd_invalidates);
+#ifdef FLASHCACHE_DO_CHECKSUMS
+		DMEMIT("\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n",
+		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid);
+#endif
+		DMEMIT("\tpending enqueues(%lu), pending inval(%lu)\n"	\
 		       "\tmetadata dirties(%lu), metadata cleans(%lu)\n" \
 		       "\tmetadata batch(%lu) metadata ssd writes(%lu)\n" \
 		       "\tcleanings(%lu) fallow cleanings(%lu)\n"	\
-		       "\tno room(%lu) front merge(%lu) back merge(%lu)\n" \
-		       "\tdisk reads(%lu), disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu), uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)",
-		       stats->read_hits, read_hit_pct,
-		       stats->write_hits, write_hit_pct,
-		       stats->dirty_write_hits, dirty_write_hit_pct,
-		       stats->replace, stats->wr_replace, 
-		       stats->wr_invalidates, stats->rd_invalidates,
-		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid,
+		       "\tno room(%lu) front merge(%lu) back merge(%lu)\n",
 		       stats->enqueues, stats->pending_inval,
 		       stats->md_write_dirty, stats->md_write_clean,
 		       stats->md_write_batch, stats->md_ssd_writes,
 		       stats->cleanings, stats->fallow_cleanings, 
-		       stats->noroom, stats->front_merge, stats->back_merge,
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
+		       stats->noroom, stats->front_merge, stats->back_merge);
 	} else if (dmc->cache_mode == FLASHCACHE_WRITE_THROUGH) {
 		DMEMIT("\tread hits(%lu), read hit percent(%d)\n"	\
 		       "\twrite hits(%lu) write hit percent(%d)\n"	\
 		       "\treplacement(%lu), write replacement(%lu)\n"	\
-		       "\twrite invalidates(%lu), read invalidates(%lu)\n" \
-		       "\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n" \
-		       "\tpending enqueues(%lu), pending inval(%lu)\n"	\
-		       "\tno room(%lu)\n" \
-		       "\tdisk reads(%lu), disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu), uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)",
+		       "\twrite invalidates(%lu), read invalidates(%lu)\n",
 		       stats->read_hits, read_hit_pct,
 		       stats->write_hits, write_hit_pct,
 		       stats->replace, stats->wr_replace, 
-		       stats->wr_invalidates, stats->rd_invalidates,
-		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid,
-		       stats->enqueues, stats->pending_inval,
-		       stats->noroom, 
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	} else {	/* WRITE_AROUND */
-		DMEMIT("\tread hits(%lu), read hit percent(%d)\n"	\
-		       "\treplacement(%lu), write replacement(%lu)\n"	\
-		       "\tinvalidates(%lu)\n" \
-		       "\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n" \
-		       "\tpending enqueues(%lu), pending inval(%lu)\n"	\
-		       "\tno room(%lu)\n" \
-		       "\tdisk reads(%lu), disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu), uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)",
-		       stats->read_hits, read_hit_pct,
-		       stats->replace, stats->wr_replace, 
-		       stats->rd_invalidates,
-		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid,
-		       stats->enqueues, stats->pending_inval,
-		       stats->noroom, 
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	}
-#else
-	if (dmc->cache_mode == FLASHCACHE_WRITE_BACK) {
-		DMEMIT("\tread hits(%lu), read hit percent(%d)\n"	\
-		       "\twrite hits(%lu) write hit percent(%d)\n"	\
-		       "\tdirty write hits(%lu) dirty write hit percent(%d)\n" \
-		       "\treplacement(%lu) write replacement(%lu)\n"	\
-		       "\twrite invalidates(%lu) read invalidates(%lu)\n" \
-		       "\tpending enqueues(%lu) pending inval(%lu)\n"	\
-		       "\tmetadata dirties(%lu) metadata cleans(%lu)\n" \
-		       "\tmetadata batch(%lu) metadata ssd writes(%lu)\n" \
-		       "\tcleanings(%lu) fallow cleanings(%lu)\n"	\
-		       "\tno room(%lu) front merge(%lu) back merge(%lu)\n" \
-		       "\tdisk reads(%lu) disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu) uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu) pid_dels(%lu) pid_drops(%lu) pid_expiry(%lu)",
-		       stats->read_hits, read_hit_pct,
-		       stats->write_hits, write_hit_pct,
-		       stats->dirty_write_hits, dirty_write_hit_pct,
-		       stats->replace, stats->wr_replace, 
-		       stats->wr_invalidates, stats->rd_invalidates,
-		       stats->enqueues, stats->pending_inval,
-		       stats->md_write_dirty, stats->md_write_clean,
-		       stats->md_write_batch, stats->md_ssd_writes,
-		       stats->cleanings, stats->fallow_cleanings, 
-		       stats->noroom, stats->front_merge, stats->back_merge,
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	} else if (dmc->cache_mode == FLASHCACHE_WRITE_THROUGH) {
-		DMEMIT("\tread hits(%lu), read hit percent(%d)\n"	\
-		       "\twrite hits(%lu) write hit percent(%d)\n"	\
-		       "\treplacement(%lu) write replacement(%lu)\n"	\
-		       "\twrite invalidates(%lu) read invalidates(%lu)\n" \
-		       "\tpending enqueues(%lu) pending inval(%lu)\n"	\
-		       "\tno room(%lu)\n" \
-		       "\tdisk reads(%lu) disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu) uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu) pid_dels(%lu) pid_drops(%lu) pid_expiry(%lu)",
-		       stats->read_hits, read_hit_pct,
-		       stats->write_hits, write_hit_pct,
-		       stats->replace, stats->wr_replace, 
-		       stats->wr_invalidates, stats->rd_invalidates,
-		       stats->enqueues, stats->pending_inval,
-		       stats->noroom, 
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	} else {	/* WRITE_AROUND */
-		DMEMIT("\tread hits(%lu), read hit percent(%d)\n"	\
-		       "\treplacement(%lu))\n"	\
-		       "\tinvalidates(%lu)\n" \
-		       "\tpending enqueues(%lu) pending inval(%lu)\n"	\
-		       "\tno room(%lu)\n" \
-		       "\tdisk reads(%lu) disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
-		       "\tuncached reads(%lu) uncached writes(%lu), uncached IO requeue(%lu)\n" \
-		       "\tpid_adds(%lu) pid_dels(%lu) pid_drops(%lu) pid_expiry(%lu)",
-		       stats->read_hits, read_hit_pct,
-		       stats->replace,
-		       stats->rd_invalidates,
-		       stats->enqueues, stats->pending_inval,
-		       stats->noroom, 
-		       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
-		       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
-		       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	}
+		       stats->wr_invalidates, stats->rd_invalidates);
+#ifdef FLASHCACHE_DO_CHECKSUMS
+		DMEMIT("\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n",
+		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid);
 #endif
+		DMEMIT("\tpending enqueues(%lu), pending inval(%lu)\n"	\
+		       "\tno room(%lu)\n",
+		       stats->enqueues, stats->pending_inval,
+		       stats->noroom);
+	} else {	/* WRITE_AROUND */
+		DMEMIT("\tread hits(%lu), read hit percent(%d)\n"	\
+		       "\treplacement(%lu), write replacement(%lu)\n"	\
+		       "\tinvalidates(%lu)\n",
+		       stats->read_hits, read_hit_pct,
+		       stats->replace, stats->wr_replace, 
+		       stats->rd_invalidates);
+#ifdef FLASHCACHE_DO_CHECKSUMS
+		DMEMIT("\tchecksum store(%ld), checksum valid(%ld), checksum invalid(%ld)\n",
+		       stats->checksum_store, stats->checksum_valid, stats->checksum_invalid);
+#endif
+		DMEMIT("\tpending enqueues(%lu), pending inval(%lu)\n"	\
+		       "\tno room(%lu)\n",
+		       stats->enqueues, stats->pending_inval,
+		       stats->noroom);
+	}
+	/* All modes */
+	DMEMIT("\tdisk reads(%lu), disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
+	       "\tuncached reads(%lu), uncached writes(%lu), uncached IO requeue(%lu)\n" \
+	       "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)",
+	       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
+	       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
+	       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
 	if (dmc->sysctl_io_latency_hist) {
 		int i;
 		

--- a/src/flashcache_procfs.c
+++ b/src/flashcache_procfs.c
@@ -741,142 +741,57 @@ flashcache_stats_show(struct seq_file *seq, void *v)
 		write_hit_pct = 0;
 		dirty_write_hit_pct = 0;
 	}
-	seq_printf(seq, "reads=%lu writes=%lu \n", stats->reads, stats->writes);
+	seq_printf(seq, "reads=%lu writes=%lu \n", 
+		   stats->reads, stats->writes);
+	seq_printf(seq, "read_hits=%lu read_hit_percent=%d ", 
+		   stats->read_hits, read_hit_pct);
+	if (dmc->cache_mode == FLASHCACHE_WRITE_BACK || dmc->cache_mode == FLASHCACHE_WRITE_THROUGH) {
+		seq_printf(seq, "write_hits=%lu write_hit_percent=%d ", 
+		   	   stats->write_hits, write_hit_pct);
+	}
+	if (dmc->cache_mode == FLASHCACHE_WRITE_BACK) {
+		seq_printf(seq, "dirty_write_hits=%lu dirty_write_hit_percent=%d ",
+			   stats->dirty_write_hits, dirty_write_hit_pct);
+	}
+	if (dmc->cache_mode == FLASHCACHE_WRITE_BACK || dmc->cache_mode == FLASHCACHE_WRITE_THROUGH) {
+		seq_printf(seq, "replacement=%lu write_replacement=%lu ",
+			   stats->replace, stats->wr_replace);
+		seq_printf(seq,  "write_invalidates=%lu read_invalidates=%lu ",
+			   stats->wr_invalidates, stats->rd_invalidates);
+	} else {	/* WRITE_AROUND */
+		seq_printf(seq, "replacement=%lu ",
+			   stats->replace);
+		seq_printf(seq, "read_invalidates=%lu ",
+			   stats->rd_invalidates);
+	}
 #ifdef FLASHCACHE_DO_CHECKSUMS
-	if (dmc->cache_mode == FLASHCACHE_WRITE_BACK) {
-		seq_printf(seq, "read_hits=%lu read_hit_percent=%d write_hits=%lu write_hit_percent=%d ",
-			   stats->read_hits, read_hit_pct,
-			   stats->write_hits, write_hit_pct);
-		seq_printf(seq, "dirty_write_hits=%lu dirty_write_hit_percent=%d ",
-			   stats->dirty_write_hits, dirty_write_hit_pct);
-		seq_printf(seq, "replacement=%lu write_replacement=%lu ",
-			   stats->replace, stats->wr_replace);
-		seq_printf(seq,  "write_invalidates=%lu read_invalidates=%lu ",
-			   stats->wr_invalidates, stats->rd_invalidates);
-		seq_printf(seq,  "checksum_store=%ld checksum_valid=%ld checksum_invalid=%ld ",
-			   stats->checksum_store, stats->checksum_valid, stats->checksum_invalid);
-		seq_printf(seq,  "pending_enqueues=%lu pending_inval=%lu ",
-			   stats->enqueues, stats->pending_inval);
-		seq_printf(seq, "metadata_dirties=%lu metadata_cleans=%lu ",
-			   stats->md_write_dirty, stats->md_write_clean);
-		seq_printf(seq, "metadata_batch=%lu metadata_ssd_writes=%lu ",
-			   stats->md_write_batch, stats->md_ssd_writes);
-		seq_printf(seq, "cleanings=%lu fallow_cleanings=%lu ",
-			   stats->cleanings, stats->fallow_cleanings);
-		seq_printf(seq, "no_room=%lu front_merge=%lu back_merge=%lu ",
-			   stats->noroom, stats->front_merge, stats->back_merge);
-		seq_printf(seq,  "disk_reads=%lu disk_writes=%lu ssd_reads=%lu ssd_writes=%lu ",
-			   stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes);
-		seq_printf(seq,  "uncached_reads=%lu uncached_writes=%lu uncached_IO_requeue=%lu ",
-			   stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeus);
-		seq_printf(seq, "pid_adds=%lu pid_dels=%lu pid_drops=%lu pid_expiry=%lu\n",
-			   stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	} else if (dmc->cache_mode == FLASHCACHE_WRITE_THROUGH) {
-		seq_printf(seq, "read_hits=%lu read_hit_percent=%d ",
-			   stats->read_hits, read_hit_pct);
-		seq_printf(seq, "write_hits=%lu write_hit_percent=%d ",
-			   stats->write_hits, write_hit_pct);
-		seq_printf(seq, "replacement=%lu write_replacement=%lu ",
-			   stats->replace, stats->wr_replace);
-		seq_printf(seq, "write_invalidates=%lu read_invalidates=%lu ",
-			   stats->wr_invalidates, stats->rd_invalidates);
-		seq_printf(seq, "checksum_store=%ld checksum_valid=%ld checksum_invalid=%ld ",
-			   stats->checksum_store, stats->checksum_valid, stats->checksum_invalid);
-		seq_printf(seq, "pending_enqueues=%lu pending_inval=%lu ",
-			   stats->enqueues, stats->pending_inval);
-		seq_printf(seq, "no room(%lu) ",
-			   stats->noroom);
-		seq_printf(seq, "disk_reads=%lu disk_writes=%lu ssd_reads=%lu ssd_writes=%lu ",
-			   stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes);
-		seq_printf(seq, "uncached_reads=%lu uncached_writes=%lu uncached_IO_requeue=%lu ",
-			   stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue);
-		seq_printf(seq, "pid_adds=%lu pid_dels=%lu pid_drops=%lu pid_expiry=%lu\n",
-			   stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	} else {	/* WRITE_AROUND */
-		seq_printf(seq, "read_hits=%lu read_hit_percent=%d ",
-			   stats->read_hits, read_hit_pct);
-		seq_printf(seq, "replacement=%lu ",
-			   stats->replace);
-		seq_printf(seq, "read_invalidates=%lu ",
-			   stats->rd_invalidates);
-		seq_printf(seq, "checksum_store=%ld checksum_valid=%ld checksum_invalid=%ld ",
-			   stats->checksum_store, stats->checksum_valid, stats->checksum_invalid);
-		seq_printf(seq, "pending_enqueues=%lu pending_inval=%lu ",
-			   stats->enqueues, stats->pending_inval);
-		seq_printf(seq, "no room(%lu) ",
-			   stats->noroom);
-		seq_printf(seq, "disk_reads=%lu disk_writes=%lu ssd_reads=%lu ssd_writes=%lu ",
-			   stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes);
-		seq_printf(seq, "uncached_reads=%lu uncached_writes=%lu uncached_IO_requeue=%lu ",
-			   stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue);
-		seq_printf(seq, "pid_adds=%lu pid_dels=%lu pid_drops=%lu pid_expiry=%lu\n",
-			   stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	}
-#else
-	if (dmc->cache_mode == FLASHCACHE_WRITE_BACK) {
-		seq_printf(seq, "read_hits=%lu read_hit_percent=%d write_hits=%lu write_hit_percent=%d ",
-			   stats->read_hits, read_hit_pct,
-			   stats->write_hits, write_hit_pct);
-		seq_printf(seq, "dirty_write_hits=%lu dirty_write_hit_percent=%d ",
-			   stats->dirty_write_hits, dirty_write_hit_pct);
-		seq_printf(seq, "replacement=%lu write_replacement=%lu ",
-			   stats->replace, stats->wr_replace);
-		seq_printf(seq,  "write_invalidates=%lu read_invalidates=%lu ",
-			   stats->wr_invalidates, stats->rd_invalidates);
-		seq_printf(seq,  "pending_enqueues=%lu pending_inval=%lu ",
-			   stats->enqueues, stats->pending_inval);
-		seq_printf(seq, "metadata_dirties=%lu metadata_cleans=%lu ",
-			   stats->md_write_dirty, stats->md_write_clean);
-		seq_printf(seq, "metadata_batch=%lu metadata_ssd_writes=%lu ",
-			   stats->md_write_batch, stats->md_ssd_writes);
-		seq_printf(seq, "cleanings=%lu fallow_cleanings=%lu ",
-			   stats->cleanings, stats->fallow_cleanings);
-		seq_printf(seq, "no_room=%lu front_merge=%lu back_merge=%lu ",
-			   stats->noroom, stats->front_merge, stats->back_merge);
-		seq_printf(seq,  "disk_reads=%lu disk_writes=%lu ssd_reads=%lu ssd_writes=%lu ",
-			   stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes);
-		seq_printf(seq,  "uncached_reads=%lu uncached_writes=%lu uncached_IO_requeue=%lu ",
-			   stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue);
-		seq_printf(seq, "pid_adds=%lu pid_dels=%lu pid_drops=%lu pid_expiry=%lu\n",
-			   stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	} else if (dmc->cache_mode == FLASHCACHE_WRITE_THROUGH) {
-		seq_printf(seq, "read_hits=%lu read_hit_percent=%d ",
-			   stats->read_hits, read_hit_pct);
-		seq_printf(seq, "write_hits=%lu write_hit_percent=%d ",
-			   stats->write_hits, write_hit_pct);
-		seq_printf(seq, "replacement=%lu write_replacement=%lu ",
-			   stats->replace, stats->wr_replace);
-		seq_printf(seq, "write_invalidates=%lu read_invalidates=%lu ",
-			   stats->wr_invalidates, stats->rd_invalidates);
-		seq_printf(seq, "pending_enqueues=%lu pending_inval=%lu ",
-			   stats->enqueues, stats->pending_inval);
-		seq_printf(seq, "no room(%lu) ",
-			   stats->noroom);
-		seq_printf(seq, "disk_reads=%lu disk_writes=%lu ssd_reads=%lu ssd_writes=%lu ",
-			   stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes);
-		seq_printf(seq, "uncached_reads=%lu uncached_writes=%lu uncached_IO_requeue=%lu ",
-			   stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue);
-		seq_printf(seq, "pid_adds=%lu pid_dels=%lu pid_drops=%lu pid_expiry=%lu\n",
-			   stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	} else {	/* WRITE_AROUND */
-		seq_printf(seq, "read_hits=%lu read_hit_percent=%d ",
-			   stats->read_hits, read_hit_pct);
-		seq_printf(seq, "replacement=%lu ",
-			   stats->replace);
-		seq_printf(seq, "read_invalidates=%lu ",
-			   stats->rd_invalidates);
-		seq_printf(seq, "pending_enqueues=%lu pending_inval=%lu ",
-			   stats->enqueues, stats->pending_inval);
-		seq_printf(seq, "no room(%lu) ",
-			   stats->noroom);
-		seq_printf(seq, "disk_reads=%lu disk_writes=%lu ssd_reads=%lu ssd_writes=%lu ",
-			   stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes);
-		seq_printf(seq, "uncached_reads=%lu uncached_writes=%lu uncached_IO_requeue=%lu ",
-			   stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue);
-		seq_printf(seq, "pid_adds=%lu pid_dels=%lu pid_drops=%lu pid_expiry=%lu\n",
-			   stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
-	}
+	seq_printf(seq,  "checksum_store=%ld checksum_valid=%ld checksum_invalid=%ld ",
+		stats->checksum_store, stats->checksum_valid, stats->checksum_invalid);
 #endif
+	seq_printf(seq,  "pending_enqueues=%lu pending_inval=%lu ",
+		   stats->enqueues, stats->pending_inval);
+
+	if (dmc->cache_mode == FLASHCACHE_WRITE_BACK) { 
+		seq_printf(seq, "metadata_dirties=%lu metadata_cleans=%lu ",
+			   stats->md_write_dirty, stats->md_write_clean);
+		seq_printf(seq, "metadata_batch=%lu metadata_ssd_writes=%lu ",
+			   stats->md_write_batch, stats->md_ssd_writes);
+		seq_printf(seq, "cleanings=%lu fallow_cleanings=%lu ",
+			   stats->cleanings, stats->fallow_cleanings);
+	}
+	seq_printf(seq, "no_room=%lu ",
+		   stats->noroom);
+
+	if (dmc->cache_mode == FLASHCACHE_WRITE_BACK) {
+ 		seq_printf(seq, "front_merge=%lu back_merge=%lu ",
+			   stats->front_merge, stats->back_merge);
+	}
+	seq_printf(seq,  "disk_reads=%lu disk_writes=%lu ssd_reads=%lu ssd_writes=%lu ",
+		   stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes);
+	seq_printf(seq,  "uncached_reads=%lu uncached_writes=%lu uncached_IO_requeue=%lu ",
+		   stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue);
+	seq_printf(seq, "pid_adds=%lu pid_dels=%lu pid_drops=%lu pid_expiry=%lu\n",
+		   stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
 	return 0;
 }
 


### PR DESCRIPTION
There were lots of lines in both sides of #ifdef FLASHCACHE_DO_CHECKSUMS, all related to dumping out stats.  

By rearranging the order (small #ifdef's within if()s rather than the other way around), I have managed to remove large duplicated blocks and reduce the line counts of 2 files by ~100 lines each without changing the output.
