### PR TITLE
Fix to allow FlashCache to compile on CentOS 6

### DIFF
--- a/src/flashcache_conf.c
+++ b/src/flashcache_conf.c
@@ -1646,10 +1646,10 @@ flashcache_init(void)
 		return r;
 	}
 #else /* LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,22) */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,0,0)
-	flashcache_io_client = dm_io_client_create(FLASHCACHE_COPY_PAGES);
-#else
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)) || (defined(RHEL_MAJOR) && RHEL_MAJOR >= 6)
 	flashcache_io_client = dm_io_client_create();
+#else
+        flashcache_io_client = dm_io_client_create(FLASHCACHE_COPY_PAGES);
 #endif
 	if (IS_ERR(flashcache_io_client)) {
 		DMERR("flashcache_init: Failed to initialize DM IO client");
@@ -1658,7 +1658,7 @@ flashcache_init(void)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,26)
 	r = kcopyd_client_create(FLASHCACHE_COPY_PAGES, &flashcache_kcp_client);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)) || (defined(RHEL_MAJOR) && RHEL_MAJOR >= 6)
 	flashcache_kcp_client = dm_kcopyd_client_create();
 	if ((r = IS_ERR(flashcache_kcp_client))) {
 		r = PTR_ERR(flashcache_kcp_client);


### PR DESCRIPTION
Compiling FlashCache current fails on CentOS 6 with the following error:

```
DKMS make.log for flashcache-1.0-121-g20e567f48970 for kernel 2.6.32-220.2.1.el6.x86_64 (x86_64)
Mon Dec 26 19:44:51 HKT 2011
make[1]: Entering directory `/var/lib/dkms/flashcache/1.0-121-g20e567f48970/build'
make -C /lib/modules/2.6.32-220.2.1.el6.x86_64/build M=/var/lib/dkms/flashcache/1.0-121-g20e567f48970/build modules V=0
make[2]: Entering directory `/usr/src/kernels/2.6.32-220.2.1.el6.x86_64'
  CC [M]  /var/lib/dkms/flashcache/1.0-121-g20e567f48970/build/flashcache_conf.o
/var/lib/dkms/flashcache/1.0-121-g20e567f48970/build/flashcache_conf.c: In function âflashcache_initâ:
/var/lib/dkms/flashcache/1.0-121-g20e567f48970/build/flashcache_conf.c:1650: error: too many arguments to function âdm_io_client_createâ
/var/lib/dkms/flashcache/1.0-121-g20e567f48970/build/flashcache_conf.c:1667: error: too many arguments to function âdm_kcopyd_client_createâ
/var/lib/dkms/flashcache/1.0-121-g20e567f48970/build/flashcache_conf.c:1667: warning: assignment makes integer from pointer without a cast
make[3]: *** [/var/lib/dkms/flashcache/1.0-121-g20e567f48970/build/flashcache_conf.o] Error 1
make[2]: *** [_module_/var/lib/dkms/flashcache/1.0-121-g20e567f48970/build] Error 2
make[2]: Leaving directory `/usr/src/kernels/2.6.32-220.2.1.el6.x86_64'
make[1]: *** [modules] Error 2
make[1]: Leaving directory `/var/lib/dkms/flashcache/1.0-121-g20e567f48970/build'
```

The Redhat kernel seems to have patched dm-io.h as follows from the vanilla 2.6.32 source:

```
< struct dm_io_client *dm_io_client_create(unsigned num_pages);

---
> struct dm_io_client *dm_io_client_create(void);
```

and dm-kcopyd.h:

```
< int dm_kcopyd_client_create(unsigned num_pages,
<                           struct dm_kcopyd_client **result);

---
> struct dm_kcopyd_client *dm_kcopyd_client_create(void);
```

This commit adds a check for patched CentOS 6 kernel sources.
