### PR TITLE
Fix RHEL6 compile error properly

### DIFF
--- a/src/flashcache_conf.c
+++ b/src/flashcache_conf.c
@@ -1646,7 +1646,7 @@ flashcache_init(void)
 		return r;
 	}
 #else /* LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,22) */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0) || defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= 1538)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)) || (defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= 1538))
 	flashcache_io_client = dm_io_client_create();
 #else
 	flashcache_io_client = dm_io_client_create(FLASHCACHE_COPY_PAGES);
@@ -1658,7 +1658,7 @@ flashcache_init(void)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,26)
 	r = kcopyd_client_create(FLASHCACHE_COPY_PAGES, &flashcache_kcp_client);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0) || defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= 1538)
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)) || (defined(RHEL_RELEASE_CODE) && (RHEL_RELEASE_CODE >= 1538))
 	flashcache_kcp_client = dm_kcopyd_client_create();
 	if ((r = IS_ERR(flashcache_kcp_client))) {
 		r = PTR_ERR(flashcache_kcp_client);


### PR DESCRIPTION
As discussed on mail, this works with all RHEL6 kernels, not just the newest ones, which is important eg. for current OpenVZ RHEL6 kernel.
