### PR TITLE
Distribute load / Stop syncing

### DIFF
--- a/doc/flashcache-sa-guide.txt
+++ b/doc/flashcache-sa-guide.txt
@@ -294,11 +294,9 @@ dev.flashcache.<cachedev>.split_io_by_usec = 1
 dev.flashcache.<cachedev>.split_io_chunk_size = 200
 	Chunk size (in blocks) for IO splitting.
 dev.flashcache.<cachedev>.cache_read_freq = 100
-	How often to read from cache device when block is available in cache, in percents.
+	How often try to search the block in cache while reading.
 dev.flashcache.<cachedev>.cache_write_freq = 100
 	How often to write into cache device, in percents.
-dev.flashcache.<cachedev>.cache_dirty_freq = 100
-	How oten to write into cache device, when block is already cached, but clear. Such a write will make block dirty.
 dev.flashcache.<cachedev>.background_sync_active = 1
 	This option allows to stop syncing of dirty blocks for a while.
 
@@ -306,7 +304,7 @@ Distributing IO between cache and source device :
 ===============================================
 
 In some cases one may need to distribute read/write operations between cache and source device. The percent of read/write operations which must be directed to the cache
-device can be set by tuning sysctls cache_read_freq, cache_write_freq and cache_dirty_freq.
+device can be set by tuning sysctls cache_read_freq and cache_write_freq.
 
 Two strategies available:
  1) split_io_by_usec = 1  : IO will be splitted by timer. For example, in case cache_read_freq=20% and split_io_chunk_size=1000, 20*1000=20000 usecs all read operations

--- a/src/flashcache.h
+++ b/src/flashcache.h
@@ -270,14 +270,6 @@ struct cache_c {
 	char cache_devname[DEV_PATHLEN];
 	char disk_devname[DEV_PATHLEN];
 
-	unsigned long read_cache_counter;
-	unsigned long read_direct_counter;
-	unsigned long write_hit_dirty_to_cache;
-	unsigned long write_hit_clean_to_cache;
-	unsigned long write_hit_clean_direct;
-	unsigned long write_miss_to_cache;
-	unsigned long write_miss_direct;
-
 	/* Per device sysctls */
 	int sysctl_io_latency_hist;
 	int sysctl_do_sync;
@@ -289,7 +281,6 @@ struct cache_c {
 	int sysctl_reclaim_policy;
 	int sysctl_cache_read_freq;
 	int sysctl_cache_write_freq;
-	int sysctl_cache_dirty_freq;
 	int sysctl_split_io_chunk_size;
 	int sysctl_split_io_by_usec;
 	int sysctl_zerostats;

--- a/src/flashcache_conf.c
+++ b/src/flashcache_conf.c
@@ -1098,14 +1098,6 @@ init:
 	dmc->max_clean_ios_total = MAX_CLEAN_IOS_TOTAL;
 	dmc->max_clean_ios_set = MAX_CLEAN_IOS_SET;
 
-	dmc->read_cache_counter = 0;
-	dmc->read_direct_counter = 0;
-	dmc->write_hit_dirty_to_cache = 0;
-	dmc->write_hit_clean_to_cache = 0;
-	dmc->write_hit_clean_direct = 0;
-	dmc->write_miss_to_cache = 0;
-	dmc->write_miss_direct = 0;
-
 	/* Other sysctl defaults */
 	dmc->sysctl_io_latency_hist = 0;
 	dmc->sysctl_do_sync = 0;
@@ -1116,7 +1108,6 @@ init:
 	dmc->sysctl_reclaim_policy = FLASHCACHE_FIFO;
 	dmc->sysctl_cache_read_freq = 100;
 	dmc->sysctl_cache_write_freq = 100;
-	dmc->sysctl_cache_dirty_freq = 100;
 	dmc->sysctl_split_io_chunk_size = 200;
 	dmc->sysctl_split_io_by_usec = 1;
 	dmc->sysctl_zerostats = 0;
@@ -1262,24 +1253,15 @@ flashcache_dtr_stats_print(struct cache_c *dmc)
 		       stats->enqueues, stats->pending_inval,
 		       stats->noroom);
 	}
-
 	/* All modes */
         DMINFO("\tdisk reads(%lu), disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
                "\tuncached reads(%lu), uncached writes(%lu), uncached IO requeue(%lu)\n" \
 	       "\tuncached sequential reads(%lu), uncached sequential writes(%lu)\n" \
-               "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)\n" \
-	       "\tcache_reads=%lu direct_reads=%lu\n" \
-	       "\twrite_hit_dirty_to_cache=%lu write_hit_clean_to_cache=%lu\n" \
-	       "\twrite_hit_clean_direct=%lu write_miss_to_cache=%lu\n" \
-	       "\twrite_miss_direct=%lu\n",
+               "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)",
                stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
                stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
 	       stats->uncached_sequential_reads, stats->uncached_sequential_writes,
-               stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry,
-	       dmc->read_cache_counter, dmc->read_direct_counter,
-	       dmc->write_hit_dirty_to_cache, dmc->write_hit_clean_to_cache,
-	       dmc->write_hit_clean_direct, dmc->write_miss_to_cache,
-	       dmc->write_miss_direct);
+               stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
 	if (dmc->size > 0) {
 		dirty_pct = ((u_int64_t)dmc->nr_dirty * 100) / dmc->size;
 		cache_pct = ((u_int64_t)dmc->cached_blocks * 100) / dmc->size;
@@ -1455,19 +1437,11 @@ flashcache_status_info(struct cache_c *dmc, status_type_t type,
 	DMEMIT("\tdisk reads(%lu), disk writes(%lu) ssd reads(%lu) ssd writes(%lu)\n" \
 	       "\tuncached reads(%lu), uncached writes(%lu), uncached IO requeue(%lu)\n" \
 	       "\tuncached sequential reads(%lu), uncached sequential writes(%lu)\n" \
-	       "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)\n" \
-	       "\tcache_reads=%lu direct_reads=%lu\n" \
-	       "\twrite_hit_dirty_to_cache=%lu write_hit_clean_to_cache=%lu\n" \
-	       "\twrite_hit_clean_direct=%lu write_miss_to_cache=%lu\n" \
-	       "\twrite_miss_direct=%lu\n",
+	       "\tpid_adds(%lu), pid_dels(%lu), pid_drops(%lu) pid_expiry(%lu)",
 	       stats->disk_reads, stats->disk_writes, stats->ssd_reads, stats->ssd_writes,
 	       stats->uncached_reads, stats->uncached_writes, stats->uncached_io_requeue,
 	       stats->uncached_sequential_reads, stats->uncached_sequential_writes,
-	       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry,
-	       dmc->read_cache_counter, dmc->read_direct_counter,
-	       dmc->write_hit_dirty_to_cache, dmc->write_hit_clean_to_cache,
-	       dmc->write_hit_clean_direct, dmc->write_miss_to_cache,
-	       dmc->write_miss_direct);
+	       stats->pid_adds, stats->pid_dels, stats->pid_drops, stats->expiry);
 	if (dmc->sysctl_io_latency_hist) {
 		int i;
 		

--- a/src/flashcache_procfs.c
+++ b/src/flashcache_procfs.c
@@ -212,7 +212,7 @@ flashcache_dirty_thresh_sysctl(ctl_table *table, int write,
  * entries - zero padded at the end ! Therefore the NUM_*_SYSCTLS
  * is 1 more than then number of sysctls.
  */
-#define FLASHCACHE_NUM_WRITEBACK_SYSCTLS	23
+#define FLASHCACHE_NUM_WRITEBACK_SYSCTLS	22
 
 static struct flashcache_writeback_sysctl_table {
 	struct ctl_table_header *sysctl_header;
@@ -335,15 +335,6 @@ static struct flashcache_writeback_sysctl_table {
 			.ctl_name	= CTL_UNNUMBERED,
 #endif
 			.procname	= "cache_write_freq",
-			.maxlen		= sizeof(int),
-			.mode		= 0644,
-			.proc_handler	= &proc_dointvec,
-		},
-		{
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
-			.ctl_name	= CTL_UNNUMBERED,
-#endif
-			.procname	= "cache_dirty_freq",
 			.maxlen		= sizeof(int),
 			.mode		= 0644,
 			.proc_handler	= &proc_dointvec,
@@ -492,7 +483,7 @@ static struct flashcache_writeback_sysctl_table {
  * entries - zero padded at the end ! Therefore the NUM_*_SYSCTLS
  * is 1 more than then number of sysctls.
  */
-#define FLASHCACHE_NUM_WRITETHROUGH_SYSCTLS	15
+#define FLASHCACHE_NUM_WRITETHROUGH_SYSCTLS	14
 
 static struct flashcache_writethrough_sysctl_table {
 	struct ctl_table_header *sysctl_header;
@@ -564,15 +555,6 @@ static struct flashcache_writethrough_sysctl_table {
 			.ctl_name	= CTL_UNNUMBERED,
 #endif
 			.procname	= "cache_write_freq",
-			.maxlen		= sizeof(int),
-			.mode		= 0644,
-			.proc_handler	= &proc_dointvec,
-		},
-		{
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
-			.ctl_name	= CTL_UNNUMBERED,
-#endif
-			.procname	= "cache_dirty_freq",
 			.maxlen		= sizeof(int),
 			.mode		= 0644,
 			.proc_handler	= &proc_dointvec,
@@ -713,8 +695,6 @@ flashcache_find_sysctl_data(struct cache_c *dmc, ctl_table *vars)
 		return &dmc->sysctl_cache_read_freq;
 	else if (strcmp(vars->procname, "cache_write_freq") == 0) 
 		return &dmc->sysctl_cache_write_freq;
-	else if (strcmp(vars->procname, "cache_dirty_freq") == 0) 
-		return &dmc->sysctl_cache_dirty_freq;
 	else if (strcmp(vars->procname, "split_io_by_usec") == 0) 
 		return &dmc->sysctl_split_io_by_usec;
 	else if (strcmp(vars->procname, "split_io_chunk_size") == 0) 


### PR DESCRIPTION
1. Now possible to distribute the load between SSD and source device
2. sysctl parameter which allows to stop syncing of dirty blocks for a while.
