### PR TITLE
fix on SusE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ KERNEL_TREE ?= /lib/modules/$(shell uname -r)/build
 export COMMIT_REV
 
 # Check for RHEL/CentOS
-RHEL5_VER ?= $(shell grep 5.[0-9] /etc/redhat-release)
+RHEL5_VER ?= $(shell if [ -e /etc/redhat-release ]; then grep 5.[0-9] /etc/redhat-release; else false; fi)
 ifneq "$(RHEL5_VER)" ""
 	RHEL5_TREE := /usr/src/redhat/BUILD/kernel-2.6.18/linux-$(shell uname -r).$(shell uname -i)
 	KERNEL_TREE := $(RHEL5_TREE)

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ EXTRA_CFLAGS += -I$(KERNEL_TREE)/drivers/md -I./ -DCOMMIT_REV="\"$(COMMIT_REV)\"
 EXTRA_CFLAGS += -I$(KERNEL_TREE)/include/ -I$(KERNEL_TREE)/include/linux 
 
 # Check for RHEL/CentOS
-RHEL5_VER ?= $(shell grep 5.[0-9] /etc/redhat-release)
+RHEL5_VER ?= $(shell  if [ -e /etc/redhat-release ]; then grep 5.[0-9] /etc/redhat-release; else false; fi)
 RHEL5_SETUP :=
 ifneq "$(RHEL5_VER)" ""
 	RHEL5_SETUP := rhel5-setup


### PR DESCRIPTION
SuSE does not provide a /etc/redhat-release file, so better not break
when file does not exist
