### PR TITLE
Fix use-after-free in flashcache_destroy

### DIFF
--- a/src/utils/flashcache_destroy.c
+++ b/src/utils/flashcache_destroy.c
@@ -51,6 +51,7 @@ usage(char *pname)
 }
 
 char *pname;
+char *sb_buf;
 char *buf;
 
 main(int argc, char **argv)
@@ -84,16 +85,16 @@ main(int argc, char **argv)
 		exit(1);
 	}
         lseek(cache_fd, 0, SEEK_SET);
-	buf = (char *)malloc(512);
-	if (!buf) {
+	sb_buf = (char *)malloc(512);
+	if (!sb_buf) {
 		fprintf(stderr, "Failed to allocate sector buffer\n");
 		exit(1);
 	}
-	if (read(cache_fd, buf, 512) < 0) {
+	if (read(cache_fd, sb_buf, 512) < 0) {
 		fprintf(stderr, "Cannot read Flashcache superblock %s\n", ssd_devname);
 		exit(1);		
 	}
-	sb = (struct flash_superblock *)buf;
+	sb = (struct flash_superblock *)sb_buf;
 	if (!(sb->cache_sb_state == CACHE_MD_STATE_DIRTY ||
 	      sb->cache_sb_state == CACHE_MD_STATE_CLEAN ||
 	      sb->cache_sb_state == CACHE_MD_STATE_FASTCLEAN ||
@@ -113,7 +114,6 @@ main(int argc, char **argv)
         lseek(cache_fd, md_block_bytes, SEEK_SET); /* lseek past the superblock to first MD slot */
 	md_slots_per_block = (md_block_bytes / (sizeof(struct flash_cacheblock)));
 
-	free(buf);
 	buf = (char *)malloc(md_block_bytes);
 	if (!buf) {
 		fprintf(stderr, "Failed to allocate sector buffer\n");
@@ -154,7 +154,7 @@ main(int argc, char **argv)
 		pname, ssd_devname);
 	sb->cache_sb_state = 0;
         lseek(cache_fd, 0, SEEK_SET);
-	if (write(cache_fd, buf, 512) < 0) {
+	if (write(cache_fd, sb_buf, 512) < 0) {
 		fprintf(stderr, "Cannot write Flashcache superblock %s\n", ssd_devname);
 		exit(1);		
 	}


### PR DESCRIPTION
The sb variable points to buf. Then buf gets freed and reallocated, so the sb pointer points to freed memory. The variable is then reused to invalidate the cache_sb_state, which is writing to memory that has been freed. In addition, that change never gets saved because the buf that is written to disk does not point to the same memory as sb.

Fixed this by using a separate buffer for the superblock that doesn't get freed.
