### PR TITLE
Depmod should be run on the right kernel

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -42,7 +42,7 @@ utils:
 modules_install: modules
 	install -o root -g root -m 0755 -d $(DESTDIR)/lib/modules/$(KERNEL_SOURCE_VERSION)/extra/flashcache/
 	install -o root -g root -m 0755 flashcache.ko $(DESTDIR)/lib/modules/$(KERNEL_SOURCE_VERSION)/extra/flashcache/
-	depmod -a
+	depmod -a $(KERNEL_SOURCE_VERSION)
 
 .PHONY: utils_install
 utils_install: utils


### PR DESCRIPTION
Depmod is run on the current kernel by default, but in most cases (the module being recompiled), you'll want to run it on the new version from $(KERNEL_SOURCE_VERSION)
