### PR TITLE
Cleanup target function signatures

### DIFF
--- a/src/flashcache.h
+++ b/src/flashcache.h
@@ -523,8 +523,12 @@ struct dbn_index_pair {
 /* Inject a 5s delay between syncing blocks and metadata */
 #define FLASHCACHE_SYNC_REMOVE_DELAY		5000
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,8,0)
 int flashcache_map(struct dm_target *ti, struct bio *bio,
 		   union map_info *map_context);
+#else
+int flashcache_map(struct dm_target *ti, struct bio *bio);
+#endif
 int flashcache_ctr(struct dm_target *ti, unsigned int argc,
 		   char **argv);
 void flashcache_dtr(struct dm_target *ti);

--- a/src/flashcache_conf.c
+++ b/src/flashcache_conf.c
@@ -1514,12 +1514,18 @@ flashcache_status_table(struct cache_c *dmc, status_type_t type,
  *  Output cache stats upon request of device status;
  *  Output cache configuration upon request of table status.
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,9,0)
+void
+flashcache_status(struct dm_target *ti, status_type_t type,
+		  unsigned int unused_status_flags,
+		  char *result, unsigned int maxlen)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
 int
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
 flashcache_status(struct dm_target *ti, status_type_t type,
 		  unsigned int unused_status_flags,
 		  char *result, unsigned int maxlen)
 #else
+int
 flashcache_status(struct dm_target *ti, status_type_t type,
 		  char *result, unsigned int maxlen)
 #endif
@@ -1534,12 +1540,14 @@ flashcache_status(struct dm_target *ti, status_type_t type,
 		flashcache_status_table(dmc, type, result, maxlen);
 		break;
 	}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,9,0)
 	return 0;
+#endif
 }
 
 static struct target_type flashcache_target = {
 	.name   = "flashcache",
-	.version= {1, 0, 3},
+	.version= {1, 0, 4},
 	.module = THIS_MODULE,
 	.ctr    = flashcache_ctr,
 	.dtr    = flashcache_dtr,

--- a/src/flashcache_main.c
+++ b/src/flashcache_main.c
@@ -1753,9 +1753,13 @@ flashcache_write(struct cache_c *dmc, struct bio *bio)
 /*
  * Decide the mapping and perform necessary cache operations for a bio request.
  */
-int 
+int
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,8,0)
 flashcache_map(struct dm_target *ti, struct bio *bio,
 	       union map_info *map_context)
+#else
+flashcache_map(struct dm_target *ti, struct bio *bio)
+#endif
 {
 	struct cache_c *dmc = (struct cache_c *) ti->private;
 	int sectors = to_sector(bio->bi_size);


### PR DESCRIPTION
Remove compilation warnings by making signatures match new kernel
headers. The map function lost its last (unused) argument in 7de3ee57da
The status function was changed to not return int anymore in fd7c092e71
