### PR TITLE
Fix trivial warnings in utils

### DIFF
--- a/src/utils/flashcache_create.c
+++ b/src/utils/flashcache_create.c
@@ -25,6 +25,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+#include <ctype.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <linux/fs.h>
@@ -189,6 +190,7 @@ check_sure(void)
 	}
 }
 
+int
 main(int argc, char **argv)
 {
 	int cache_fd, disk_fd, c;
@@ -361,4 +363,5 @@ main(int argc, char **argv)
 		fprintf(stderr, "%s failed\n", dmsetup_cmd);
 		exit(1);
 	}
+	return 0;
 }

--- a/src/utils/flashcache_destroy.c
+++ b/src/utils/flashcache_destroy.c
@@ -54,13 +54,12 @@ char *pname;
 char *sb_buf;
 char *buf;
 
+int
 main(int argc, char **argv)
 {
-	int cache_fd, disk_fd, c;
-	char *disk_devname, *ssd_devname, *cachedev;
+	int cache_fd, c;
+	char *ssd_devname;
 	struct flash_superblock *sb;
-	sector_t cache_devsize, disk_devsize;
-	sector_t block_size = 0;
 	u_int64_t md_block_bytes = 0;
 	u_int64_t md_slots_per_block = 0;
 	u_int64_t cache_size = 0;
@@ -158,4 +157,5 @@ main(int argc, char **argv)
 		fprintf(stderr, "Cannot write Flashcache superblock %s\n", ssd_devname);
 		exit(1);		
 	}
+	return 0;
 }

--- a/src/utils/flashcache_load.c
+++ b/src/utils/flashcache_load.c
@@ -75,10 +75,6 @@ module_loaded(void)
 static void
 load_module(void)
 {
-	FILE *fp;
-	char line[8192];
-	int found = 0;
-
 	if (module_loaded()) {
 		if (verbose)
 			fprintf(stderr, "Flashcache Module already loaded\n");		
@@ -93,6 +89,7 @@ load_module(void)
 	}
 }
 
+int
 main(int argc, char **argv)
 {
 	int c, cache_fd, disk_fd;
@@ -189,4 +186,5 @@ main(int argc, char **argv)
 		fprintf(stderr, "%s failed\n", dmsetup_cmd);
 		exit(1);
 	}
+	return 0;
 }

--- a/src/utils/flashcache_setioctl.c
+++ b/src/utils/flashcache_setioctl.c
@@ -42,6 +42,7 @@ void usage(char *pname)
 	exit(1);
 }
 
+int
 main(int argc, char **argv)
 {
 	int cache_fd, c, result;
@@ -130,5 +131,6 @@ main(int argc, char **argv)
 		fprintf(stderr, "ioctl failed on %s\n", cachedev);
 		exit(1);
 	}
+	return 0;
 }
 

--- a/src/utils/get_agsize.c
+++ b/src/utils/get_agsize.c
@@ -43,7 +43,7 @@ int
 main(int argc, char *argv[])
 {
 	size_t csize, vsize, agsize, t1, t2, diff, best_agcount = 1;
-	int i, agcount;
+	int agcount;
 	int c, verbose = 0;
 	char *pname;
 
@@ -92,4 +92,5 @@ main(int argc, char *argv[])
 	}
 	printf("best agsize = %ld agcount=%d\n", 
 	       vsize / (best_agcount * 1024), best_agcount);
+	return 0;
 }


### PR DESCRIPTION
Removed unused variables and added more explicit returns to make the
real warnings actually stand out.
