### PR TITLE
Update flashcache_reclaim.c

### DIFF
--- a/src/flashcache_reclaim.c
+++ b/src/flashcache_reclaim.c
@@ -402,7 +402,7 @@ flashcache_reclaim_demote_block(struct cache_c *dmc, int index)
 	int start_index = set * dmc->assoc;
 
 	VERIFY(cacheblk->lru_state & LRU_HOT);
-	warm_block = cache_set->warmlist_lru_head;
+	warm_block = cache_set->warmlist_lru_tail;
 	if (warm_block == FLASHCACHE_NULL)
 		/* We cannot swap this block into the warm list */
 		return 0;


### PR DESCRIPTION
The function of flashcache_reclaim_demote_block() is to swap this hot block with the MRU block in the warm queue.

And the MRU block in the warm queue is related to warmlist_lru_tail,so

the code:
warm_block = cache_set->warmlist_lru_head; 

should be:
warm_block = cache_set->warmlist_lru_tail;
