### PR TITLE
Update flashcache_main.c

### DIFF
--- a/src/flashcache_main.c
+++ b/src/flashcache_main.c
@@ -297,6 +297,7 @@ flashcache_io_callback(unsigned long error, void *context)
 		} else {
 			dmc->flashcache_errors.ssd_write_errors++;
 			if (dmc->cache_mode == FLASHCACHE_WRITE_THROUGH)
+			{
 				/* 
 				 * We don't know if the IO failed because of a ssd write
 				 * error or a disk write error. Bump up both.
@@ -306,6 +307,7 @@ flashcache_io_callback(unsigned long error, void *context)
 				 */
 			        disk_error = -EIO;
 				dmc->flashcache_errors.disk_write_errors++;
+			}
 		}
 		break;
 	}


### PR DESCRIPTION
I think the pair of brackets are necessary.
In the case of writecache, when a error occurs, 
if the cache_mode is FLASHCACHE_WRITE_THROUGH,we should add 1 to both of ssd_write_errors and disk_write_errors(in the current version of flashcache).
If the cache_mode is FLASHCACHE_WRITE_BACK,we should only add 1 to ssd_write_errors.
Without the pair of brackets,no matter which cache_mode it is,both of ssd_write_errors and disk_write_errors will be added by 1,then the conditional judgement " if (dmc->cache_mode == FLASHCACHE_WRITE_THROUGH) " makes no sense.
