### PR TITLE
The block should be alloced sequential

### DIFF
--- a/src/flashcache.h
+++ b/src/flashcache.h
@@ -192,7 +192,7 @@ struct cache_set {
 	u_int16_t               lru_hot_blocks, lru_warm_blocks;
 #define NUM_BLOCK_HASH_BUCKETS		512
 	u_int16_t		hash_buckets[NUM_BLOCK_HASH_BUCKETS];
-	u_int16_t		invalid_head;
+	u_int16_t		invalid_head, invalid_tail;
 };
 
 struct flashcache_errors {

--- a/src/flashcache_subr.c
+++ b/src/flashcache_subr.c
@@ -190,12 +190,17 @@ flashcache_invalid_insert(struct cache_c *dmc, int index)
 	/* It cannot be on the per-set hash */
 	VERIFY(cacheblk->hash_prev == FLASHCACHE_NULL);
 	VERIFY(cacheblk->hash_next == FLASHCACHE_NULL);
-	/* Insert this block at the head of the invalid list */
+
+	/* Insert this block at the tail of the invalid list */
 	cache_set = &dmc->cache_sets[set];
-	cacheblk->hash_next = cache_set->invalid_head;
-	if (cache_set->invalid_head != FLASHCACHE_NULL)
-		dmc->cache[start_index + cache_set->invalid_head].hash_prev = set_ix;
-	cache_set->invalid_head = set_ix;
+	cacheblk->hash_next = FLASHCACHE_NULL;
+	if (cache_set->invalid_tail != FLASHCACHE_NULL)
+		dmc->cache[start_index + cache_set->invalid_tail].hash_next = set_ix;
+	cacheblk->hash_prev = cache_set->invalid_tail;
+
+	if (cache_set->invalid_head == FLASHCACHE_NULL)
+		cache_set->invalid_head = set_ix;
+	cache_set->invalid_tail = set_ix;
 }
 
 void
@@ -222,10 +227,11 @@ flashcache_invalid_remove(struct cache_c *dmc, int index)
 	if (cacheblk->hash_next != FLASHCACHE_NULL) {
 		dmc->cache[start_index + cacheblk->hash_next].hash_prev = 
 			cacheblk->hash_prev;
-	}
+	} else
+		cache_set->invalid_tail = cacheblk->hash_prev;
+
 	cacheblk->hash_prev = FLASHCACHE_NULL;
 	cacheblk->hash_next = FLASHCACHE_NULL;
-	
 }
 
 /* Cache set block hash management */
@@ -238,6 +244,7 @@ flashcache_hash_init(struct cache_c *dmc)
 	for (i = 0 ; i < (dmc->size >> dmc->assoc_shift) ; i++) {
 		cache_set = &dmc->cache_sets[i];
 		cache_set->invalid_head = FLASHCACHE_NULL;
+		cache_set->invalid_tail = FLASHCACHE_NULL;
 		for (j = 0 ; j < NUM_BLOCK_HASH_BUCKETS ; j++) 
 			cache_set->hash_buckets[j] = FLASHCACHE_NULL;
 	}


### PR DESCRIPTION
Currently the invalid blocks are inserted into the list head - which
are also removed from the list head. Say if there are blocks with DBN
from 1 to 10 are got freed one by one (e.g once after the initialization)
and inserted into the invalid list. Then DBN 10 will be alloced first,
and DBN 9, and DBN 8, and so on.
Therefore if they are alloced by a seqread cachemiss read, the following
repeated cacheread will read SSD in reverse order, which is bad even for
a SSD since the device readahead cannot be activated.

-zyh
