### PR TITLE
Fix build error on Linux 4.3.

### DIFF
--- a/src/flashcache_subr.c
+++ b/src/flashcache_subr.c
@@ -736,8 +736,11 @@ flashcache_bio_endio(struct bio *bio, int error,
 		flashcache_record_latency(dmc, start_time);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,24)
 	bio_endio(bio, bio->bi_size, error);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,3,0)
 	bio_endio(bio, error);
+#else
+	bio->bi_error = error;
+	bio_endio(bio);
 #endif	
 }
 


### PR DESCRIPTION
Fix build after Linux 4.3-rc1 commit 4246a0b63bd8f56a1469b12eafeb875b1041a451
("block: add a bi_error field to struct bio").

src/flashcache_subr.c: In function ‘flashcache_bio_endio’:
src/flashcache_subr.c:740:2: error: too many arguments to function ‘bio_endio’
  bio_endio(bio, error);
  ^
In file included from include/linux/blkdev.h:18:0,
                 from src/flashcache_subr.c:29:
include/linux/bio.h:433:13: note: declared here
 extern void bio_endio(struct bio *);
             ^

Signed-off-by: Vinson Lee vlee@freedesktop.org
