### PR TITLE
Switch from ioctl to dm target messages for PID blacklist/whitelist manipulation

### DIFF
--- a/src/flashcache_conf.c
+++ b/src/flashcache_conf.c
@@ -1713,7 +1713,12 @@ static struct target_type flashcache_target = {
 	.dtr    = flashcache_dtr,
 	.map    = flashcache_map,
 	.status = flashcache_status,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
 	.ioctl 	= flashcache_ioctl,
+#else
+	.prepare_ioctl 	= flashcache_prepare_ioctl,
+	.message        = flashcache_message,
+#endif
 	.iterate_devices = flashcache_iterate_devices,
 };
 

--- a/src/flashcache_ioctl.h
+++ b/src/flashcache_ioctl.h
@@ -51,6 +51,11 @@ enum {
 #define FLASHCACHEDELALLWHITELIST	_IOW(FLASHCACHE_IOCTL, FLASHCACHEDELWHITELISTALL_CMD, pid_t)
 
 #ifdef __KERNEL__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+int flashcache_message(struct dm_target *ti, unsigned argc, char **argv);
+int flashcache_prepare_ioctl(struct dm_target *ti,
+                             struct block_device **bdev, fmode_t *mode);
+#else
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,27)
 int flashcache_ioctl(struct dm_target *ti, struct inode *inode,
 		     struct file *filp, unsigned int cmd,
@@ -58,6 +63,7 @@ int flashcache_ioctl(struct dm_target *ti, struct inode *inode,
 #else
 int flashcache_ioctl(struct dm_target *ti, unsigned int cmd,
  		     unsigned long arg);
+#endif
 #endif
 void flashcache_pid_expiry_all_locked(struct cache_c *dmc);
 int flashcache_uncacheable(struct cache_c *dmc, struct bio *bio);


### PR DESCRIPTION
In mainline 4.4 the ioctl() callback in the DM target has been removed
in favour of a prepare_ioctl() which selects the underlying device,
all ioctls are assume to apply to that.  In discussions with upstream on
resolving this it was suggested that the correct mechanism for this
kind of target focussed ioctl is actually DM target messages.  This
patch converts the blacklist/whitelist manipulation over to these DM
target messages.

It also adds rather primative support to the flashcache_setioctl helper to
switch to DM target messages when the existing ioctls are not supported
(ENOTTY).  This is handled by calling out to dmsetup which offers a
message command to form these requests.

I would envisage it would be possible to reduce flashcache_setioctl to a
simple shell script in the future once there is no possibility of these
tools being used with a kernel supporting the ioctl only.

This should fix the hard parts of issue #215.

fixes: #215
Signed-off-by: Andy Whitcroft apw@ubuntu.com
