### PR TITLE
Typo in flashcache_create.mdwn

### DIFF
--- a/man/flashcache_create.mdwn
+++ b/man/flashcache_create.mdwn
@@ -58,7 +58,7 @@ performance) enabling the writethrough mode may decrease the system write
 performance. All disk reads are cached (tunable through flashcache's */proc*
 interface).
 
-*Writearound* (**ardound**) - again, very safe, writes are not written to the
+*Writearound* (**around**) - again, very safe, writes are not written to the
 cache device, but directly to the backend disk instead.  Disk blocks will only
 be cached after they are read.  All disk reads are cached (tunable through
 flashcache's */proc* interface).


### PR DESCRIPTION
**Typo at line 61, detected via man flashcache_create**

I contacted Dmitry Smirnov as he appeared at the bottom of manpages, he recommended me to create a pull request.  

Here's the conversation:

```
Hello Iván,

On Tue, 16 Feb 2016 04:21:09 PM Iván Ariel Barrera Oro wrote:
> There's a typo in the manual page of flascache_create.
> Under caching modes, writearound says /ardound/.
> Attached there's a picture illustrating it.

Thanks for reposting. Indeed I see the problem on the following page:

https://github.com/facebook/flashcache/blob/master/man/flashcache_create.mdwn

However I'm no longer involved with flashcache and I have too little time to 
address the issue. You should be able to open a bug report (or better pull 
request) directly on project web site:

    https://github.com/facebook/flashcache

Thank you.

-- 
Cheers,
 Dmitry Smirnov
 GPG key : 4096R/53968D1B
```
