### PR TITLE
Systemd init support for loading cache volumes

### DIFF
--- a/README
+++ b/README
@@ -27,5 +27,12 @@ This builds both the flashcache.ko and 3 utilities.
 flascache-sa-guide.txt has details on how to create and load
 flashcache volumes.
 
+Loading flashcache volumes on Systemd :
+-------------------------------------
+On folder "systemd" you will find the necessary components and a
+README file that describes how to set up those files to load
+flashcache volumes when using this init system.
+
 Mohan Srinivasan
 Paul Saab
+Manuel Bernal-Llinares

--- a/systemd/README
+++ b/systemd/README
@@ -9,6 +9,13 @@ the system:
     - flashcache_loader, this script is called by the service "start" action, it parses the flashcachetab file, and
     calls flashcache_load to activate the cache volumes specified on the file.
     - flashcachetab, this file contains a flashcache volume per line, with optional volume name, to be activated by
-    flashcache_loader script. It should be placed at /etc
+    flashcache_loader script.
+    - flashcache_vol.conf, sysctl style file with configuration parameters for the cache volumes
+
+All these files should be installed at:
+/etc/systemd/system/flashcache.service
+/etc/init.d/flashcache_loader
+/etc/flashcache/flashcachetab
+/etc/flashcache/flashcache_vol.conf (optional)
 
 This files have been tested on a Debian 8.4, using flashcache compiled from its source code at github.com/facebookarchive/flashcache

--- a/systemd/README
+++ b/systemd/README
@@ -1,0 +1,14 @@
+Systemd bootup for Flashcache
+Author: Manuel Bernal Llinares
+------------------------------
+
+This folder contains three files for loading flashcache volumes when booting
+the system:
+    - flashcache.service, contains the service definition, usually placed at /etc/systemd/system/flashcache.service,
+    with permissions 664.
+    - flashcache_loader, this script is called by the service "start" action, it parses the flashcachetab file, and
+    calls flashcache_load to activate the cache volumes specified on the file.
+    - flashcachetab, this file contains a flashcache volume per line, with optional volume name, to be activated by
+    flashcache_loader script. It should be placed at /etc
+
+This files have been tested on a Debian 8.4, using flashcache compiled from its source code at github.com/facebookarchive/flashcache

--- a/systemd/flashcache.service
+++ b/systemd/flashcache.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Flashcache volumes loading service
+DefaultDependencies=no
+Requires=lvm2-monitor.service -.mount boot.mount lvm2-activation-early.service lvm2-activation.service systemd-fsck-root.service systemd-remount-fs.service
+After=lvm2-monintor.service -.mount boot.mount lvm2-activation-early.service lvm2-activation.service systemd-fsck-root.service systemd-remount-fs.service
+Wants=lvm2-monitor.service lvm2-activation-early.service lvm2-activation.service
+Before=checkfs.service mountall.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/etc/init.d/flashcache_loader
+
+[Install]
+WantedBy=default.target

--- a/systemd/flashcache_loader
+++ b/systemd/flashcache_loader
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Parse the flashcachetab file and load the cache volumes
+
+# Tools
+EGREP=$(which egrep)
+
+# File with cache volumes listing
+FLASHCACHETAB=/etc/flashcachetab
+
+cat "$FLASHCACHETAB" | $EGREP -v "^#" | while read line ;
+    do
+        items=($line)
+        echo "Loading ${items[0]} (${items[1]})"
+        if flashcache_load ${items[0]} ${items[1]} 2> /dev/null; then
+           echo "Flashcache volume ${items[1]} loaded from ${items[0]}"
+        else
+            (>&2 echo "ERROR loading Flashcache volume ${items[1]} loaded from ${items[0]}") 
+        fi
+    done
+

--- a/systemd/flashcache_loader
+++ b/systemd/flashcache_loader
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-# Parse the flashcachetab file and load the cache volumes
-
-# Tools
+# PATH
+#PATH=/sbin:/bin:/usr/bin
 EGREP=$(which egrep)
+SYSCTL=$(which sysctl)
 
 # File with cache volumes listing
-FLASHCACHETAB=/etc/flashcachetab
+ETC_FLASHCACHE=/etc/flashcache
+FLASHCACHETAB=$ETC_FLASHCACHE/flashcachetab
+VOLUMES_SYSCTL_PARAMS=$ETC_FLASHCACHE/flashcache_vol.conf
 
 cat "$FLASHCACHETAB" | $EGREP -v "^#" | while read line ;
     do
@@ -18,4 +20,9 @@ cat "$FLASHCACHETAB" | $EGREP -v "^#" | while read line ;
             (>&2 echo "ERROR loading Flashcache volume ${items[1]} loaded from ${items[0]}") 
         fi
     done
-
+if [ -f "$VOLUMES_SYSCTL_PARAMS" ] ; then 
+    echo "Loading cache volumes configuration from $VOLUMES_SYSCTL_PARAMS"
+    $SYSCTL -p "$VOLUMES_SYSCTL_PARAMS"
+else
+    echo "No cache volumes configuration file has been found!"
+fi

--- a/systemd/flashcache_vol.conf
+++ b/systemd/flashcache_vol.conf
@@ -1,0 +1,6 @@
+# Configuration parameters for the flashcache cache volumes
+#
+# The easiest way to customize your cache volumes parameters is, once the volumes
+# have been created, run
+# sysctl -a | grep flashcache >> /etc/flashcache/flashcache_vol.conf
+# Then, edit the file to tweak the parameters for each volume

--- a/systemd/flashcachetab
+++ b/systemd/flashcachetab
@@ -1,0 +1,2 @@
+# This file contains a list of devices from which to load flashcache volumes
+# <cache_device>    <optional_cache_volume_name>


### PR DESCRIPTION
Hi guys, I just wrote a few files to support Systemd init system.
I've tested this on a Debian 8.4.
I still have to solve a little issue with flashcache sysctl volumes parameters, not being applied when loading the volumes, probably because procps gets executed too early, but that will be an easy extension of the flashcache_loader script
This software is great fulfilling its goal, specially for absorbing burst writes to a slow backend like the Seagate Archive drives.
Thanks,
Manuel
