### PR TITLE
Fix misleading-indentation error.

### DIFF
--- a/src/flashcache_main.c
+++ b/src/flashcache_main.c
@@ -325,7 +325,7 @@ flashcache_io_callback(unsigned long error, void *context)
 			}
 		} else {
 			dmc->flashcache_errors.ssd_write_errors++;
-			if (dmc->cache_mode == FLASHCACHE_WRITE_THROUGH)
+			if (dmc->cache_mode == FLASHCACHE_WRITE_THROUGH) {
 				/* 
 				 * We don't know if the IO failed because of a ssd write
 				 * error or a disk write error. Bump up both.
@@ -335,6 +335,7 @@ flashcache_io_callback(unsigned long error, void *context)
 				 */
 			        disk_error = -EIO;
 				dmc->flashcache_errors.disk_write_errors++;
+			}
 		}
 		break;
 	}


### PR DESCRIPTION
flashcache_main.c: In function ‘flashcache_io_callback’:
flashcache_main.c:328:4: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
    if (dmc->cache_mode == FLASHCACHE_WRITE_THROUGH)
    ^~

Fixes: 9cb6e3a8f2f7 ("Disambiguate ssd errors and disk errors on IO completion. On IO completion for the !WRITEBACK case, issue an uncached disk IO in the case of a SSD error. Patch submitted by Mohit Saxena.")
Signed-off-by: Vinson Lee <vlee@freedesktop.org>